### PR TITLE
Implement "actuator activation" to compensate drive latency

### DIFF
--- a/components/venetian_blinds/cover.py
+++ b/components/venetian_blinds/cover.py
@@ -13,6 +13,7 @@ from esphome.const import (
 )
 
 CONF_TILT_DURATION = "tilt_duration"
+CONF_ACTUATOR_ACTIVATION_DURATION = "actuator_activation_duration"
 
 venetian_blinds_ns = cg.esphome_ns.namespace('venetian_blinds')
 VenetianBlinds = venetian_blinds_ns.class_('VenetianBlinds', cover.Cover, cg.Component)
@@ -25,6 +26,7 @@ CONFIG_SCHEMA = cover.COVER_SCHEMA.extend({
     cv.Required(CONF_CLOSE_DURATION): cv.positive_time_period_milliseconds,
     cv.Required(CONF_STOP_ACTION): automation.validate_automation(single=True),
     cv.Required(CONF_TILT_DURATION): cv.positive_time_period_milliseconds,
+    cv.Optional(CONF_ACTUATOR_ACTIVATION_DURATION, default="0s"): cv.positive_time_period_milliseconds,
     cv.Optional(CONF_ASSUMED_STATE, default=True): cv.boolean,
 }).extend(cv.COMPONENT_SCHEMA)
 
@@ -44,4 +46,5 @@ async def to_code(config):
         var.get_close_trigger(), [], config[CONF_CLOSE_ACTION]
     )
     cg.add(var.set_tilt_duration(config[CONF_TILT_DURATION]))
+    cg.add(var.set_actuator_activation_duration(config[CONF_ACTUATOR_ACTIVATION_DURATION]))
     cg.add(var.set_assumed_state(config[CONF_ASSUMED_STATE]))

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -209,10 +209,10 @@ void VenetianBlinds::recompute_position_() {
     this->exact_position_ += direction * tilt_overflow;
     this->exact_position_ = clamp(this->exact_position_, 0, action_duration);
   }
-    
+
   this->position = this->exact_position_ / (float)action_duration;
   this->tilt = this->exact_tilt_ / (float)this->tilt_duration;
-  
+
   this->last_recompute_time_ = now;
 }
 

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -35,8 +35,10 @@ void VenetianBlinds::setup() {
     this->position = 0.0;
     this->tilt = 0.0;
   }
-  this->open_net_duration_ = this->open_duration - this->tilt_duration;
-  this->close_net_duration_ = this->close_duration - this->tilt_duration;
+  const uint32_t tilt_and_activation_duration = this->tilt_duration +
+      this->actuator_activation_duration;
+  this->open_net_duration_ = this->open_duration - tilt_and_activation_duration;
+  this->close_net_duration_ = this->close_duration - tilt_and_activation_duration;
 
   this->exact_position_ =
       this->close_net_duration_ *

--- a/components/venetian_blinds/venetian_blinds.h
+++ b/components/venetian_blinds/venetian_blinds.h
@@ -19,6 +19,7 @@ public:
   void set_open_duration(uint32_t open) { this->open_duration = open; }
   void set_close_duration(uint32_t close) { this->close_duration = close; }
   void set_tilt_duration(uint32_t tilt) { this->tilt_duration = tilt; }
+  void set_actuator_activation_duration(uint32_t actuator_activation) { this->actuator_activation_duration = actuator_activation; }
   void set_assumed_state(bool value) { this->assumed_state = value; }
 
 protected:
@@ -28,6 +29,7 @@ protected:
   uint32_t open_duration;
   uint32_t close_duration;
   uint32_t tilt_duration;
+  uint32_t actuator_activation_duration;
   bool assumed_state{false};
 
 private:


### PR DESCRIPTION
Implement "actuator activation" like discussed in #7 

One implementation detail i am not sure about is, wether "actuator activation duration" should be considered for open_net_duration_/close_net_duration_. ~~I am leaning towards adding that (not done currently).~~ I implemented it this way.