### PR TITLE
Basing this on time based cover

### DIFF
--- a/components/venetian_blinds/cover.py
+++ b/components/venetian_blinds/cover.py
@@ -13,6 +13,7 @@ from esphome.const import (
 )
 
 CONF_TILT_DURATION = "tilt_duration"
+CONF_ACTUATOR_ACTIVATION_DURATION = "actuator_activation_duration"
 
 venetian_blinds_ns = cg.esphome_ns.namespace('venetian_blinds')
 VenetianBlinds = venetian_blinds_ns.class_('VenetianBlinds', cover.Cover, cg.Component)
@@ -25,6 +26,7 @@ CONFIG_SCHEMA = cover.COVER_SCHEMA.extend({
     cv.Required(CONF_CLOSE_DURATION): cv.positive_time_period_milliseconds,
     cv.Required(CONF_STOP_ACTION): automation.validate_automation(single=True),
     cv.Required(CONF_TILT_DURATION): cv.positive_time_period_milliseconds,
+    cv.Optional(CONF_ACTUATOR_ACTIVATION_DURATION, default="0s"): cv.positive_time_period_milliseconds,
     cv.Optional(CONF_ASSUMED_STATE, default=True): cv.boolean,
 }).extend(cv.COMPONENT_SCHEMA)
 
@@ -44,4 +46,5 @@ async def to_code(config):
         var.get_close_trigger(), [], config[CONF_CLOSE_ACTION]
     )
     cg.add(var.set_tilt_duration(config[CONF_TILT_DURATION]))
+    cg.add(var.set_actuator_activation_duration(config[CONF_ACTUATOR_ACTIVATION_DURATION]))
     cg.add(var.set_assumed_state(config[CONF_ASSUMED_STATE]))

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -15,6 +15,8 @@ void VenetianBlinds::dump_config() {
   ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->close_duration / 1e3f);
   ESP_LOGCONFIG(TAG, "  Tilt Open/Close Duration: %.1fs",
                 this->tilt_duration / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Actuator Activation Duration: %.1fs",
+                this->actuator_activation_duration / 1e3f);
   ESP_LOGCONFIG(TAG, "  Open Net Duration: %.1fs",
                 this->open_net_duration_ / 1e3f);
   ESP_LOGCONFIG(TAG, "  Close Net Duration: %.1fs",
@@ -33,8 +35,10 @@ void VenetianBlinds::setup() {
     this->position = 0.0;
     this->tilt = 0.0;
   }
-  this->open_net_duration_ = this->open_duration - this->tilt_duration;
-  this->close_net_duration_ = this->close_duration - this->tilt_duration;
+  const uint32_t tilt_and_activation_duration = this->tilt_duration +
+      this->actuator_activation_duration;
+  this->open_net_duration_ = this->open_duration - tilt_and_activation_duration;
+  this->close_net_duration_ = this->close_duration - tilt_and_activation_duration;
 
   this->exact_position_ =
       this->close_net_duration_ *
@@ -168,6 +172,14 @@ void VenetianBlinds::recompute_position_() {
   if (this->current_operation == COVER_OPERATION_IDLE)
     return;
 
+  const uint32_t now = millis();
+
+  // when actuator is still activating, the position is not changed
+  const uint32_t actuator_start_time = this->start_dir_time_ + this->actuator_activation_duration;
+  const bool actuator_is_activating = now <= actuator_start_time;
+  if (actuator_is_activating)
+    return;
+
   int direction;
   int action_duration;
   int tilt_boundary;
@@ -186,9 +198,15 @@ void VenetianBlinds::recompute_position_() {
     return;
   }
 
-  const uint32_t now = millis();
-
-  this->exact_tilt_ += direction * (now - this->last_recompute_time_);
+  /*
+   * when actuator-activation finished between "start_direction_" and this
+   * invocation of "recompute_position_", movement just started and the cover
+   * moved for (now - actuator_start_time)
+   */
+  const uint32_t movement_start_time = this->last_recompute_time_ < actuator_start_time ?
+      actuator_start_time : this->last_recompute_time_;
+  const uint32_t cover_moving_time = now - movement_start_time;
+  this->exact_tilt_ += direction * cover_moving_time;
   const int tilt_overflow = direction * (this->exact_tilt_ - tilt_boundary);
   this->exact_tilt_ = clamp(this->exact_tilt_, 0, (int)this->tilt_duration);
   if (tilt_overflow > 0) {

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -1,6 +1,6 @@
 #include "venetian_blinds.h"
-#include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace venetian_blinds {
@@ -10,113 +10,195 @@ static const char *TAG = "venetian_blinds.cover";
 using namespace esphome::cover;
 
 void VenetianBlinds::dump_config() {
-    LOG_COVER("", "Venetian Blinds", this);
-    ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->open_duration / 1e3f);
-    ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->close_duration / 1e3f);
+  LOG_COVER("", "Venetian Blinds", this);
+  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->open_duration / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->close_duration / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Tilt Open/Close Duration: %.1fs",
+                this->tilt_duration / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Open Net Duration: %.1fs",
+                this->open_net_duration_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Close Net Duration: %.1fs",
+                this->close_net_duration_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Position: %.1f%", this->position);
+  ESP_LOGCONFIG(TAG, "  Tilt: %.1f%", this->tilt);
+  ESP_LOGCONFIG(TAG, "  Exact Position: %.1fs", this->exact_position_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Exact Tilt: %.1fs", this->exact_tilt_ / 1e3f);
 }
 
-void VenetianBlinds::setup() {   
-    auto restore = this->restore_state_();
-    if (restore.has_value()) {
-        restore->apply(this);
-    } else {
-        this->position = 0.0;
-        this->tilt = 0.0;
-    }
-        exact_pos = this->position;
-        exact_tilt = this->tilt;
+void VenetianBlinds::setup() {
+  auto restore = this->restore_state_();
+  if (restore.has_value()) {
+    restore->apply(this);
+  } else {
+    this->position = 0.0;
+    this->tilt = 0.0;
+  }
+  this->open_net_duration_ = this->open_duration - this->tilt_duration;
+  this->close_net_duration_ = this->close_duration - this->tilt_duration;
+
+  this->exact_position_ =
+      this->close_net_duration_ *
+      this->position; // position factor should be same for both open and close
+                      // even if both durations are different
+  this->exact_tilt_ = this->tilt_duration * this->tilt;
 }
 
 CoverTraits VenetianBlinds::get_traits() {
-    auto traits = CoverTraits();
-    traits.set_supports_position(true);
-    traits.set_supports_tilt(true);
-    traits.set_is_assumed_state(this->assumed_state);
-    return traits;
+  auto traits = CoverTraits();
+  traits.set_supports_position(true);
+  traits.set_supports_tilt(true);
+  traits.set_is_assumed_state(this->assumed_state);
+  return traits;
 }
 
 void VenetianBlinds::control(const CoverCall &call) {
-    if (call.get_tilt().has_value()) {
-        int new_tilt = *call.get_tilt()*100;
-        relative_tilt = exact_tilt - new_tilt;
-        relative_pos = 0;
-        last_position_update = millis();
-    }
-    if (call.get_position().has_value()) {
-        int new_pos = *call.get_position()*100;
-        relative_pos = exact_pos - new_pos;
-        relative_tilt = 0;
-        last_position_update = millis();
-    }
-    if (call.get_stop()) {
-        relative_pos = 0;
-        relative_tilt = 0;
-        this->stop_trigger->trigger();
-        this->current_action = COVER_OPERATION_IDLE;
-        this->position = exact_pos/100.0;
-        this->tilt = exact_tilt/100.0;
-        this->publish_state();
-    }
-}
-void VenetianBlinds::loop() {
-    uint32_t current_time = millis();
-    if(relative_pos > 0 || relative_tilt < 0) {
-        if(this->current_action != COVER_OPERATION_CLOSING) {
-            this->close_trigger->trigger();
-            this->current_action = COVER_OPERATION_CLOSING;
-        }
-        if(current_time - last_tilt_update >= (this->tilt_duration / 100)) {
-            last_tilt_update = current_time;
-            relative_tilt=clamp(relative_tilt+1,-100,0);
-            exact_tilt=clamp(exact_tilt+1,0,100);
-        }
-        if(current_time - last_position_update >= (this->open_duration / 100)) {
-            last_position_update = current_time;
-            relative_pos=clamp(relative_pos-1,0,100);
-            exact_pos--;
-            if(exact_pos % 5 == 0) {
-                this->position = exact_pos/100.0;
-                this->tilt = exact_tilt/100.0;
-                this->publish_state();
-            }
-        }
-        if(relative_pos == 0 && relative_tilt == 0) {
-            this->stop_trigger->trigger();
-            this->current_action = COVER_OPERATION_IDLE;
-            this->position = exact_pos/100.0;
-            this->tilt = exact_tilt/100.0;
-            this->publish_state();
-        }
-    } 
-    else if(relative_pos < 0 || relative_tilt > 0) {
-        if(this->current_action != COVER_OPERATION_OPENING) {
-            this->open_trigger->trigger();
-            this->current_action = COVER_OPERATION_OPENING;
-        }
-        if(current_time - last_tilt_update >= (this->tilt_duration / 100)) {
-            last_tilt_update = current_time;
-            relative_tilt=clamp(relative_tilt-1,0,100);
-            exact_tilt=clamp(exact_tilt-1,0,100);
-        }
-        if(current_time - last_position_update >= (this->close_duration / 100)) {
-            last_position_update = current_time;
-            relative_pos=clamp(relative_pos+1,-100,0);
-            exact_pos++;
-            if(exact_pos % 5 == 0) {
-                this->position = exact_pos/100.0;
-                this->tilt = exact_tilt/100.0;
-                this->publish_state();
-            }
-        }
-        if(relative_pos == 0 && relative_tilt == 0) {
-            this->stop_trigger->trigger();
-            this->current_action = COVER_OPERATION_IDLE;
-            this->position = exact_pos/100.0;
-            this->tilt = exact_tilt/100.0;
-            this->publish_state();
-        }
-    }
-};
+  if (call.get_stop()) {
+    this->start_direction_(COVER_OPERATION_IDLE);
+    this->publish_state();
+  }
+  if (call.get_position().has_value()) {
+    auto requested_position = *call.get_position();
+    if (requested_position != this->position) {
+      cover::CoverOperation operation;
+      uint32_t operation_duration;
+      if (requested_position < this->position) {
+        operation = COVER_OPERATION_CLOSING;
+        operation_duration = this->open_net_duration_;
+        this->target_tilt_ = 0.0f;
+      } else {
+        operation = COVER_OPERATION_OPENING;
+        operation_duration = this->close_net_duration_;
+        this->target_tilt_ = 1.0f;
+      }
 
+      this->target_position_ = requested_position * operation_duration;
+      this->start_direction_(operation);
+    }
+  }
+  if (call.get_tilt().has_value()) {
+    auto requested_tilt = *call.get_tilt();
+    if (requested_tilt != this->tilt) {
+      auto operation = requested_tilt < this->tilt ? COVER_OPERATION_CLOSING
+                                                   : COVER_OPERATION_OPENING;
+      this->target_position_ = this->exact_position_;
+      this->target_tilt_ = requested_tilt * this->tilt_duration;
+      this->start_direction_(operation);
+    }
+  }
 }
+
+void VenetianBlinds::loop() {
+  if (this->current_operation == COVER_OPERATION_IDLE)
+    return;
+
+  const uint32_t now = millis();
+
+  // Recompute position every loop cycle
+  this->recompute_position_();
+
+  if (this->is_at_target_()) {
+    this->start_direction_(COVER_OPERATION_IDLE);
+    this->publish_state();
+  }
+
+  // Send current position every second
+  if (now - this->last_publish_time_ > 1000) {
+    this->publish_state(false);
+    this->last_publish_time_ = now;
+  }
 }
+
+void VenetianBlinds::stop_prev_trigger_() {
+  if (this->prev_command_trigger_ != nullptr) {
+    this->prev_command_trigger_->stop_action();
+    this->prev_command_trigger_ = nullptr;
+  }
+}
+
+bool VenetianBlinds::is_at_target_() const {
+  switch (this->current_operation) {
+  case COVER_OPERATION_OPENING:
+    return this->exact_position_ >= this->target_position_ &&
+           this->exact_tilt_ >= this->target_tilt_;
+  case COVER_OPERATION_CLOSING:
+    return this->exact_position_ <= this->target_position_ &&
+           this->exact_tilt_ <= this->target_tilt_;
+  case COVER_OPERATION_IDLE:
+  default:
+    return true;
+  }
+}
+
+void VenetianBlinds::start_direction_(CoverOperation dir) {
+  if (dir == this->current_operation && dir != COVER_OPERATION_IDLE)
+    return;
+
+  this->recompute_position_();
+  Trigger<> *trig;
+  switch (dir) {
+  case COVER_OPERATION_IDLE:
+    trig = this->stop_trigger;
+    break;
+  case COVER_OPERATION_OPENING:
+    this->last_operation_ = dir;
+    trig = this->open_trigger;
+    break;
+  case COVER_OPERATION_CLOSING:
+    this->last_operation_ = dir;
+    trig = this->close_trigger;
+    break;
+  default:
+    return;
+  }
+
+  this->current_operation = dir;
+
+  const uint32_t now = millis();
+  this->start_dir_time_ = now;
+  this->last_recompute_time_ = now;
+
+  this->stop_prev_trigger_();
+  trig->trigger();
+  this->prev_command_trigger_ = trig;
+}
+
+void VenetianBlinds::recompute_position_() {
+  if (this->current_operation == COVER_OPERATION_IDLE)
+    return;
+
+  int direction;
+  int action_duration;
+  int tilt_boundary;
+  switch (this->current_operation) {
+  case COVER_OPERATION_OPENING:
+    direction = 1;
+    action_duration = this->open_net_duration_;
+    tilt_boundary = this->tilt_duration;
+    break;
+  case COVER_OPERATION_CLOSING:
+    direction = -1;
+    action_duration = this->close_net_duration_;
+    tilt_boundary = 0;
+    break;
+  default:
+    return;
+  }
+
+  const uint32_t now = millis();
+
+  this->exact_tilt_ += direction * (now - this->last_recompute_time_);
+  const int tilt_overflow = direction * (this->exact_tilt_ - tilt_boundary);
+  this->exact_tilt_ = clamp(this->exact_tilt_, 0, (int)this->tilt_duration);
+  if (tilt_overflow > 0) {
+    this->exact_position_ += direction * tilt_overflow;
+    this->exact_position_ = clamp(this->exact_position_, 0, action_duration);
+  }
+
+  this->position = this->exact_position_ / (float)action_duration;
+  this->tilt = this->exact_tilt_ / (float)this->tilt_duration;
+
+  this->last_recompute_time_ = now;
+}
+
+} // namespace venetian_blinds
+} // namespace esphome

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -63,11 +63,11 @@ void VenetianBlinds::control(const CoverCall &call) {
       uint32_t operation_duration;
       if (requested_position < this->position) {
         operation = COVER_OPERATION_CLOSING;
-        operation_duration = this->open_net_duration_;
+        operation_duration = this->close_net_duration_;
         this->target_tilt_ = 0.0f;
       } else {
         operation = COVER_OPERATION_OPENING;
-        operation_duration = this->close_net_duration_;
+        operation_duration = this->open_net_duration_;
         this->target_tilt_ = 1.0f;
       }
 

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -58,10 +58,12 @@ void VenetianBlinds::control(const CoverCall &call) {
   }
   if (call.get_position().has_value()) {
     auto requested_position = *call.get_position();
-    if (requested_position != this->position) {
+    if ((requested_position != this->position) ||
+        (requested_position == 0 && this->tilt > 0)) {
       cover::CoverOperation operation;
       uint32_t operation_duration;
-      if (requested_position < this->position) {
+      if ((requested_position < this->position) ||
+          (requested_position == 0)) {
         operation = COVER_OPERATION_CLOSING;
         operation_duration = this->close_net_duration_;
         this->target_tilt_ = 0.0f;

--- a/components/venetian_blinds/venetian_blinds.h
+++ b/components/venetian_blinds/venetian_blinds.h
@@ -1,42 +1,54 @@
 #pragma once
-#include "esphome/core/component.h"
-#include "esphome/core/automation.h"
 #include "esphome/components/cover/cover.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
 
 namespace esphome {
 namespace venetian_blinds {
 
 class VenetianBlinds : public Component, public cover::Cover {
-  public:
-    void setup() override;
-    void loop() override;
-    void dump_config() override;
-    cover::CoverTraits get_traits() override;
-    void control(const cover::CoverCall &call) override;
-    Trigger<> *get_open_trigger() const { return this->open_trigger; }
-    Trigger<> *get_close_trigger() const { return this->close_trigger; }
-    Trigger<> *get_stop_trigger() const { return this->stop_trigger; }    
-    void set_open_duration(uint32_t open) { this->open_duration = open; }
-    void set_close_duration(uint32_t close) { this->close_duration = close; }
-    void set_tilt_duration(uint32_t tilt) { this->tilt_duration = tilt; }
-    void set_assumed_state(bool value) { this->assumed_state = value; }
-  private:
-    uint32_t last_position_update{0};
-    uint32_t last_tilt_update{0};
-    int exact_pos;
-    int relative_pos{0};
-    int exact_tilt;
-    int relative_tilt{0};
-    cover::CoverOperation current_action{cover::COVER_OPERATION_IDLE};
-  protected:
-    Trigger<> *open_trigger{new Trigger<>()};
-    Trigger<> *close_trigger{new Trigger<>()};
-    Trigger<> *stop_trigger{new Trigger<>()};
-    uint32_t open_duration;
-    uint32_t close_duration;
-    uint32_t tilt_duration;
-    bool assumed_state{false};
+public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  cover::CoverTraits get_traits() override;
+  void control(const cover::CoverCall &call) override;
+  Trigger<> *get_open_trigger() const { return this->open_trigger; }
+  Trigger<> *get_close_trigger() const { return this->close_trigger; }
+  Trigger<> *get_stop_trigger() const { return this->stop_trigger; }
+  void set_open_duration(uint32_t open) { this->open_duration = open; }
+  void set_close_duration(uint32_t close) { this->close_duration = close; }
+  void set_tilt_duration(uint32_t tilt) { this->tilt_duration = tilt; }
+  void set_assumed_state(bool value) { this->assumed_state = value; }
+
+protected:
+  Trigger<> *open_trigger{new Trigger<>()};
+  Trigger<> *close_trigger{new Trigger<>()};
+  Trigger<> *stop_trigger{new Trigger<>()};
+  uint32_t open_duration;
+  uint32_t close_duration;
+  uint32_t tilt_duration;
+  bool assumed_state{false};
+
+private:
+  uint32_t start_dir_time_{0};
+  uint32_t last_recompute_time_{0};
+  uint32_t last_publish_time_{0};
+  uint32_t open_net_duration_;
+  uint32_t close_net_duration_;
+  uint32_t target_position_{0};
+  uint32_t target_tilt_{0};
+  int exact_position_{0};
+  int exact_tilt_{0};
+
+  void stop_prev_trigger_();
+  bool is_at_target_() const;
+  void start_direction_(cover::CoverOperation dir);
+  void recompute_position_();
+
+  Trigger<> *prev_command_trigger_{nullptr};
+  cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
 };
 
-}
-}
+} // namespace venetian_blinds
+} // namespace esphome

--- a/components/venetian_blinds/venetian_blinds.h
+++ b/components/venetian_blinds/venetian_blinds.h
@@ -19,6 +19,7 @@ public:
   void set_open_duration(uint32_t open) { this->open_duration = open; }
   void set_close_duration(uint32_t close) { this->close_duration = close; }
   void set_tilt_duration(uint32_t tilt) { this->tilt_duration = tilt; }
+  void set_actuator_activation_duration(uint32_t actuator_activation) { this->actuator_activation_duration = actuator_activation; }
   void set_assumed_state(bool value) { this->assumed_state = value; }
 
 protected:
@@ -28,6 +29,7 @@ protected:
   uint32_t open_duration;
   uint32_t close_duration;
   uint32_t tilt_duration;
+  uint32_t actuator_activation_duration;
   bool assumed_state{false};
 
 private:


### PR DESCRIPTION
I think it is time to merge the test branch to the master. Thanks to @pavelma for the contribution.

## Changes
This is now based on the time based cover. It features a better precision and seems to work better for some blinds that are more sensitive. On the other hand, this made it worse for some other that have a minimal actuator time duration. This is now also addressed thanks to the contribution from @DaniEll-AT.

## Breaking change
This reverses the tilt position to make it consistent with the position. So it is from 0 to 100, where 0 means closed and 100 open.