### PR TITLE
fix: add support for stopping the cover

### DIFF
--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -51,6 +51,7 @@ CoverTraits VenetianBlinds::get_traits() {
   auto traits = CoverTraits();
   traits.set_supports_position(true);
   traits.set_supports_tilt(true);
+  traits.set_supports_stop(true);
   traits.set_is_assumed_state(this->assumed_state);
   return traits;
 }


### PR DESCRIPTION
Required to be able to stop the moving cover when running on 2023.5.0 or later. Tested with 2023.7.0.

Without this, it is not possible to use the `stop_action`, like this:

```yaml
cover:
  - platform: venetian_blinds
    name: "wardrobe"
    id: cover1
    open_action:
      - switch.turn_on: up
    open_duration: 65000ms
    close_action:
      - switch.turn_on: down
    close_duration: 65000ms
    tilt_duration: 1650ms
    stop_action:
      - switch.turn_off: up
      - switch.turn_off: down
```

This PR restores this behavior for newer ESPHome.

Related:

- https://github.com/home-assistant/core/pull/80104
- https://github.com/esphome/aioesphomeapi/pull/276